### PR TITLE
Add missing emblem-default symlink

### DIFF
--- a/emblems/scalable/emblem-default.svg
+++ b/emblems/scalable/emblem-default.svg
@@ -1,0 +1,1 @@
+emblem-checked.svg


### PR DESCRIPTION
Adds an `emblem-default.svg` to `emblems` which symlinks to `emblem-checked.svg`

This icon is mostly used as an emblem to identify default settings or as a glyph for buttons to restore default settings. For example, it appears in the printer settings to indicate the current default printer.