### PR TITLE
New dialog-password icon

### DIFF
--- a/status/scalable-light/dialog-password.svg
+++ b/status/scalable-light/dialog-password.svg
@@ -12,104 +12,322 @@
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="48"
    height="48"
-   id="svg9854"
+   id="svg5453"
    version="1.1"
-   inkscape:version="0.91 r13725"
-   viewBox="0 0 48 48"
+   inkscape:version="0.48.5 r10040"
    sodipodi:docname="dialog-password.svg">
   <defs
-     id="defs9856">
+     id="defs5455">
     <linearGradient
-       inkscape:collect="always"
-       id="linearGradient10694">
+       id="linearGradient8311-06">
       <stop
-         style="stop-color:#999999;stop-opacity:1"
+         id="stop8313-6"
+         style="stop-color:#a9a3d4;stop-opacity:1"
+         offset="0" />
+      <stop
+         offset="0.47001833"
+         style="stop-color:#87baff;stop-opacity:1"
+         id="stop4462" />
+      <stop
+         id="stop8315-2"
+         style="stop-color:#89ec85;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="23.5"
+       x2="47"
+       y1="23.5"
+       x1="0"
+       id="linearGradient4460"
+       xlink:href="#linearGradient8311-06"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="517.79797"
+       x2="400.57138"
+       y1="545.79797"
+       x1="400.57138"
+       gradientTransform="matrix(1.4285729,0,0,1.4285729,-163.67403,-235.91408)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4224"
+       xlink:href="#linearGradient4180"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4180">
+      <stop
+         id="stop4182"
          offset="0"
-         id="stop10696" />
+         style="stop-color:#ff9300;stop-opacity:1;" />
       <stop
-         style="stop-color:#999999;stop-opacity:1"
+         id="stop4184"
          offset="1"
-         id="stop10698" />
+         style="stop-color:#ffd702;stop-opacity:1;" />
     </linearGradient>
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient10694"
-       id="linearGradient10700"
-       x1="-13.625"
-       y1="8.875"
-       x2="-13.375"
-       y2="-19"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(26.5,27.25)" />
+       xlink:href="#linearGradient3778"
+       id="linearGradient3784"
+       x1="514.37213"
+       y1="516.375"
+       x2="0"
+       y2="0"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3778">
+      <stop
+         style="stop-color:#b7b7b8;stop-opacity:1;"
+         offset="0"
+         id="stop3780" />
+      <stop
+         style="stop-color:#f0f0f0;stop-opacity:1;"
+         offset="1"
+         id="stop3782" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3778"
+       id="linearGradient3804"
+       x1="514.37213"
+       y1="516.375"
+       x2="0"
+       y2="0"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3806">
+      <stop
+         style="stop-color:#b7b7b8;stop-opacity:1;"
+         offset="0"
+         id="stop3808" />
+      <stop
+         style="stop-color:#f0f0f0;stop-opacity:1;"
+         offset="1"
+         id="stop3810" />
+    </linearGradient>
   </defs>
   <sodipodi:namedview
      id="base"
-     pagecolor="#ffffff"
+     pagecolor="#5a5a5a"
      bordercolor="#666666"
      borderopacity="1.0"
-     inkscape:pageopacity="0.0"
+     inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:zoom="8"
-     inkscape:cx="22.944907"
-     inkscape:cy="33.990586"
-     inkscape:current-layer="layer1"
-     showgrid="true"
-     inkscape:grid-bbox="true"
+     inkscape:zoom="8.92"
+     inkscape:cx="15.62639"
+     inkscape:cy="17.322912"
      inkscape:document-units="px"
-     inkscape:window-width="1366"
-     inkscape:window-height="712"
-     inkscape:window-x="0"
-     inkscape:window-y="28"
-     inkscape:window-maximized="1" />
+     inkscape:current-layer="layer1-0"
+     showgrid="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:window-width="1291"
+     inkscape:window-height="807"
+     inkscape:window-x="607"
+     inkscape:window-y="200"
+     inkscape:window-maximized="0"
+     inkscape:showpageshadow="false"
+     borderlayer="true"
+     showguides="false"
+     showborder="false"
+     inkscape:snap-bbox="true"
+     inkscape:snap-bbox-midpoints="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4063" />
+    <sodipodi:guide
+       position="1.1650391e-05,47.999996"
+       orientation="4,0"
+       id="guide4146" />
+    <sodipodi:guide
+       position="1.1650391e-05,43.999996"
+       orientation="0,48"
+       id="guide4148" />
+    <sodipodi:guide
+       position="48.000012,43.999996"
+       orientation="-4,0"
+       id="guide4150" />
+    <sodipodi:guide
+       position="48.000012,47.999996"
+       orientation="0,-48"
+       id="guide4152" />
+    <sodipodi:guide
+       position="1.1650391e-05,4.0000264"
+       orientation="4,0"
+       id="guide4154" />
+    <sodipodi:guide
+       position="1.1650391e-05,2.6367188e-05"
+       orientation="0,48"
+       id="guide4156" />
+    <sodipodi:guide
+       position="48.000012,2.6367188e-05"
+       orientation="-4,0"
+       id="guide4158" />
+    <sodipodi:guide
+       position="48.000012,4.0000264"
+       orientation="0,-48"
+       id="guide4160" />
+    <sodipodi:guide
+       position="48.000012,48.000026"
+       orientation="0,-4"
+       id="guide4162" />
+    <sodipodi:guide
+       position="44.000012,48.000026"
+       orientation="48,0"
+       id="guide4164" />
+    <sodipodi:guide
+       position="44.000012,2.6367188e-05"
+       orientation="0,4"
+       id="guide4166" />
+    <sodipodi:guide
+       position="48.000012,2.6367188e-05"
+       orientation="-48,0"
+       id="guide4168" />
+    <sodipodi:guide
+       position="4.0000422,48.000026"
+       orientation="0,-4"
+       id="guide4170" />
+    <sodipodi:guide
+       position="4.2167969e-05,48.000026"
+       orientation="48,0"
+       id="guide4172" />
+    <sodipodi:guide
+       position="4.2167969e-05,2.6367188e-05"
+       orientation="0,4"
+       id="guide4174" />
+    <sodipodi:guide
+       position="4.0000422,2.6367188e-05"
+       orientation="-48,0"
+       id="guide4176" />
+    <sodipodi:guide
+       position="20,30"
+       orientation="39.999969,0"
+       id="guide4153" />
+    <sodipodi:guide
+       position="20.000012,4.0000264"
+       orientation="0,8"
+       id="guide4155" />
+    <sodipodi:guide
+       position="25,30"
+       orientation="-39.999969,0"
+       id="guide4157" />
+    <sodipodi:guide
+       position="28.000012,43.999996"
+       orientation="0,-8"
+       id="guide4159" />
+    <sodipodi:guide
+       position="22,11"
+       orientation="5,0"
+       id="guide4342" />
+  </sodipodi:namedview>
   <metadata
-     id="metadata9859">
+     id="metadata5458">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     id="layer1"
      inkscape:label="Layer 1"
-     inkscape:groupmode="layer">
-    <path
-       inkscape:connector-curvature="0"
-       style="opacity:1;fill:#000000;fill-opacity:0.35294119;stroke:none;stroke-width:2;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M 14,13 A 12,12 0 0 0 2,25 12,12 0 0 0 14,37 12,12 0 0 0 25.164062,29.371094 l 9.902344,0 0.03516,3.130859 7.195313,-0.01953 -0.03516,-3.111328 3.738281,0 0,-9.541016 -21.183594,0 A 12,12 0 0 0 14,13 Z"
-       id="path10402-2" />
-    <path
-       style="opacity:1;fill:url(#linearGradient10700);fill-opacity:1;stroke:none;stroke-width:2;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M 14,12 A 12,12 0 0 0 2,24 12,12 0 0 0 14,36 12,12 0 0 0 25.164062,28.371094 l 9.902344,0 0.03516,3.130859 7.195313,-0.01953 -0.03516,-3.111328 3.738281,0 0,-9.541016 -21.183594,0 A 12,12 0 0 0 14,12 Z"
-       id="circle10626"
-       inkscape:connector-curvature="0" />
-    <circle
-       style="opacity:1;fill:#000000;fill-opacity:0.07843138;stroke:none;stroke-width:2;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="circle10622"
-       cx="13.726542"
-       cy="23.5"
-       r="3" />
-    <circle
-       r="3"
-       cy="23.857143"
-       cx="13.726542"
-       id="circle10620"
-       style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    <circle
-       style="opacity:1;fill:#ffffff;fill-opacity:0.21387287;stroke:none;stroke-width:2;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="circle10624"
-       cx="13.726542"
-       cy="24.247461"
-       r="3" />
-    <circle
-       style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="circle10632"
-       cx="13.726542"
-       cy="23.857143"
-       r="3" />
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-384.57143,-499.798)">
+    <g
+       transform="translate(392.24401,-502.51656)"
+       id="layer1-4"
+       inkscape:label="Layer 1">
+      <g
+         transform="matrix(1.138587,0,0,1.138587,-3.4562036,-142.80276)"
+         id="g4413"
+         style="stroke-width:1.31742239;stroke-miterlimit:4;stroke-dasharray:none">
+        <g
+           id="g4312"
+           transform="matrix(1.0539376,0,0,1.0539376,-0.91298719,-55.411661)">
+          <g
+             transform="matrix(0.83333358,0,0,0.83333358,-408.28112,587.90224)"
+             id="layer1-0"
+             inkscape:label="Layer 1">
+            <g
+               transform="matrix(1.1124629,0,0,1.1124629,8.2138882,-56.260483)"
+               id="g4338-1">
+              <g
+                 transform="matrix(0.84002598,0,0,0.84002598,94.722843,341.97161)"
+                 id="g4340-3">
+                <g
+                   transform="matrix(1.016661,0,0,1.016661,-5.0483185,-3.8359534)"
+                   id="g4414">
+                  <g
+                     transform="matrix(1.0525569,0,0,1.0525569,-7.0342247,-334.35283)"
+                     id="layer1-9"
+                     inkscape:label="Layer 1">
+                    <g
+                       transform="matrix(1.15,0,0,1.15,-61.285728,-78.569705)"
+                       id="g4280">
+                      <rect
+                         ry="20"
+                         y="503.798"
+                         x="388.57144"
+                         height="40"
+                         width="40"
+                         id="rect4222"
+                         style="opacity:1;fill:url(#linearGradient4224);fill-opacity:1.0;stroke:none" />
+                    </g>
+                  </g>
+                </g>
+                <g
+                   id="g4304" />
+                <g
+                   id="g4306" />
+                <g
+                   id="g4308" />
+                <g
+                   id="g4310" />
+                <g
+                   id="g4312-3" />
+                <g
+                   id="g4314" />
+                <g
+                   id="g4316" />
+                <g
+                   id="g4318" />
+                <g
+                   id="g4320" />
+                <g
+                   id="g4322" />
+                <g
+                   id="g4324" />
+                <g
+                   id="g4326" />
+                <g
+                   id="g4328-3" />
+                <g
+                   id="g4330-0" />
+                <g
+                   id="g4332-2" />
+              </g>
+            </g>
+            <g
+               id="g3-3"
+               transform="matrix(0.05162095,0,0,0.05162095,497.88091,512.94952)"
+               style="fill:#000000;fill-opacity:0.79607843">
+              <path
+                 d="M 353.812,0 C 263.925,0 191.25,72.675 191.25,162.562 c 0,19.125 3.825,38.25 9.562,57.375 L 0,420.75 l 0,95.625 95.625,0 0,-57.375 57.375,0 0,-57.375 57.375,0 86.062,-86.062 c 17.213,5.737 36.338,9.562 57.375,9.562 89.888,0 162.562,-72.675 162.562,-162.562 C 516.374,72.676 443.7,0 353.812,0 z m 47.813,172.125 c -32.513,0 -57.375,-24.862 -57.375,-57.375 0,-32.513 24.862,-57.375 57.375,-57.375 32.513,0 57.375,24.862 57.375,57.375 0,32.513 -24.862,57.375 -57.375,57.375 z"
+                 id="path5-1"
+                 inkscape:connector-curvature="0"
+                 style="fill:#000000;fill-opacity:0.79607843" />
+            </g>
+          </g>
+        </g>
+      </g>
+      <g
+         style="fill:url(#linearGradient4460);fill-opacity:1"
+         transform="matrix(0.48796879,0,0,0.48796879,21.356721,1026.8977)"
+         id="g3" />
+    </g>
   </g>
 </svg>


### PR DESCRIPTION
The current `status/scalable/dialog-password` icon doesn't match the style of La Capitaine very well.

I made a new one based on the `preferences-system-privacy` base and `encrypted-key` glyph.