### PR TITLE
increase status icon MaxSize for pkexec password dialog

### DIFF
--- a/index.theme
+++ b/index.theme
@@ -128,7 +128,7 @@ Context=Status
 Size=16
 Type=Scalable
 MinSize=8
-MaxSize=32
+MaxSize=48
 
 [status/symbolic]
 Context=Status


### PR DESCRIPTION
This edit raises the `MaxSize` of the `status/scalable` scope.

The [`pkexec`](https://www.freedesktop.org/software/polkit/docs/0.105/pkexec.1.html) password dialogs (e.g. as shipped with Synaptic or GParted on Debian) will benefit from this change as this allows them to:
1) display the `dialog-password` icon in bigger size and
1) integrate a small version of the called application's icon into the `dialog-password` icon.

See the comparison between `MaxSize=32` (top) and `MaxSize=48` (bottom) below:

![status-maxsize-comparison](https://cloud.githubusercontent.com/assets/1408105/23342915/01cd6e34-fc63-11e6-935d-928e9931de9f.png)
( the displayed `dialog-password` icon is the one from #115 )
