### PR TITLE
add roxterm and viewnior icons (symlinks)

### DIFF
--- a/apps/scalable/roxterm.svg
+++ b/apps/scalable/roxterm.svg
@@ -1,0 +1,1 @@
+terminal.svg

--- a/apps/scalable/viewnior.svg
+++ b/apps/scalable/viewnior.svg
@@ -1,0 +1,1 @@
+accessories-image-viewer.svg


### PR DESCRIPTION
Adds the following icons:
- **ROXTerm**, a GTK2/GTK3 terminal, symlinks to `terminal.svg`.
- **Viewnior**, a fast & simple image viewer, symlinks to `accessories-image-viewer.svg`.
