### PR TITLE
Added symlink for Tilix icon

### DIFF
--- a/apps/scalable/com.gexperts.Tilix.svg
+++ b/apps/scalable/com.gexperts.Tilix.svg
@@ -1,0 +1,1 @@
+terminix.svg


### PR DESCRIPTION
The app "Terminix" has recently been renamed to "Tilix". This pull request adds a new symlink, which adds an icon for Tilix by referring to the existing one. This pull request should fix issue https://github.com/keeferrourke/la-capitaine-icon-theme/issues/131.