### PR TITLE
add symlinks for qcma and ppsspp

### DIFF
--- a/apps/scalable/ppsspp.svg
+++ b/apps/scalable/ppsspp.svg
@@ -1,0 +1,1 @@
+pcsx-icon.svg

--- a/apps/scalable/qcma.svg
+++ b/apps/scalable/qcma.svg
@@ -1,0 +1,1 @@
+pcsx-icon.svg


### PR DESCRIPTION
### Description

Adds symlinks to `pcsx-icon.svg` for the following applications:
* `qcma.svg` - [Qcma](https://codestation.github.io/qcma/) a free content manager implementation for the PlayStation Vita
* `ppsspp.svg` - [PPSSPP](http://ppsspp.org/) a PlayStation Portable emulator

