### PR TITLE
Added information specifically for Ubuntu snap

### DIFF
--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -58,6 +58,9 @@ Most intelliJ IDEs in general | `Icon=/opt/intellij-ide-name/bin/ide-name.png` |
 Python 2.x | `Icon=/usr/share/pixmaps/python2.x.xpm` | `Icon=python2` or `Icon=python2.x`, as you wish
 Python 3.x | `Icon=/usr/share/pixmaps/python3.x.xpm` | `Icon=python3` or `Icon=python3.x`, as you wish
 
+Applications installed through Ubuntu Software (specifically on unbuntu 17.04+ or using snap) have a tendency to be hardcoded. The `.desktop` files for these apps can be found in `/var/lib/snapd/desktop/applications` and can be edited manually as mentioned above (assuming
+`apps/scalable/foo-icon-name.svg` exists) .
+
 This list is just what we have noticed, it might or might not be true on your
 machine. If you found another candidate for the list, tell us!
 


### PR DESCRIPTION
<!-- Please describe your changes below. -->
### Description
Apps installed through snap have hard-coded icon locations in their desktop entries. This change provides more information regarding the specifics of Ubuntu snap applications.

<!--

    If you are submitting a new icon, include a PNG preview
    of the icon below.

    If you are submitting an icon *revision*, include a PNG
    preview of the old icon, and the new iconn side-by-side.
    You may use a table such as the following:

    | Icon name     | Old Icon     | New Icon     |
    | :------------ | ------------ | ------------ |
    | `coolapp.svg` | ![](old.png) | ![](new.png) |

-->

