### PR TITLE
adding latte-dock symbolic link

### DIFF
--- a/apps/scalable/latte-dock.svg
+++ b/apps/scalable/latte-dock.svg
@@ -1,0 +1,1 @@
+plank.svg


### PR DESCRIPTION
It will be nice if latte-dock has its own icon. It is a major project in KDE now.
```
[Desktop Entry]
Name=Latte
GenericName=Dock
Icon=latte-dock
Categories=Utility;X-SuSE-DesktopUtility;
Exec=latte-dock %u
InitialPreference=1
StartupNotify=false
Terminal=false
Type=Application
StartupWMClass=latte-dock
```
Reference:
![latte-dock](https://user-images.githubusercontent.com/22009014/36439738-fb317110-1697-11e8-8dc5-a70cb4ee0d92.png)
