### PR TITLE
Fixed distromatch for elementary OS 0.4.1 Loki

### DIFF
--- a/configure
+++ b/configure
@@ -37,7 +37,7 @@ distromatch() {
     case $DISTRO in
         arch) ln -sf distributor-logo-archlinux.svg distributor-logo.svg ;;
         debian|raspbian) ln -sf distributor-logo-debian.svg distributor-logo.svg ;;
-        elementaryos) ln -sf distributor-logo-elementaryos.svg distributor-logo.svg ;;
+        elementaryos|elementary) ln -sf distributor-logo-elementaryos.svg distributor-logo.svg ;;
         fedora) ln -sf distributor-logo-fedora.svg distributor-logo.svg ;;
         gentoo) ln -sf distributor-logo-gentoo.svg distributor-logo.svg ;;
         korora) ln -sf distributor-logo-korora.svg distributor-logo.svg ;;


### PR DESCRIPTION
<!-- Please describe your changes below. -->
### Description
I use elementary OS 0.4.1 and when I try to configure icons, it don't define my distro. 
The reason of problem is **new ID** in **os-release**.
![screenshot from 2018-04-30 16-14-12](https://user-images.githubusercontent.com/34302242/39428976-0c46878a-4c92-11e8-836e-af394d25eb1d.png)

**So, I find solution of problem: just add `elementary` in case of `distromatch`.**
>  Also I think, that you need to **include this fix in the latest release** or create 0.5.1
<!--

    If you are submitting a new icon, include a PNG preview
    of the icon below.

    If you are submitting an icon *revision*, include a PNG
    preview of the old icon, and the new iconn side-by-side.
    You may use a table such as the following:

    | Icon name     | Old Icon     | New Icon     |
    | :------------ | ------------ | ------------ |
    | `coolapp.svg` | ![](old.png) | ![](new.png) |

-->

