### PR TITLE
Create symlink for gnome-music to org.gnome.Music

### DIFF
--- a/apps/scalable/org.gnome.Music.svg
+++ b/apps/scalable/org.gnome.Music.svg
@@ -1,0 +1,1 @@
+gnome-music.svg


### PR DESCRIPTION
<!-- Please describe your changes below. -->
### Description

As the title states, this PR adds a simple symlink from `org.gnome.Music.svg` to `gnome-music.svg`. `org.gnome.Music` is the icon name used for GNOME Music on Fedora 28 (and probably other platforms).

<!--

    If you are submitting a new icon, include a PNG preview
    of the icon below.

    If you are submitting an icon *revision*, include a PNG
    preview of the old icon, and the new iconn side-by-side.
    You may use a table such as the following:

    | Icon name     | Old Icon     | New Icon     |
    | :------------ | ------------ | ------------ |
    | `coolapp.svg` | ![](old.png) | ![](new.png) |

-->

