### PR TITLE
Fix xfce4-panel Status Notifier Plugin icon

### DIFF
--- a/status/symbolic/blueman-disabled-symbolic.svg
+++ b/status/symbolic/blueman-disabled-symbolic.svg
@@ -1,0 +1,1 @@
+bluetooth-disabled-symbolic.svg

--- a/status/symbolic/blueman-tray-symbolic.svg
+++ b/status/symbolic/blueman-tray-symbolic.svg
@@ -1,0 +1,1 @@
+bluetooth-active-symbolic.svg

--- a/status/symbolic/nm-no-connection-symbolic.svg
+++ b/status/symbolic/nm-no-connection-symbolic.svg
@@ -1,0 +1,1 @@
+nm-no-connection.svg

--- a/status/symbolic/nm-signal-0-symbolic.svg
+++ b/status/symbolic/nm-signal-0-symbolic.svg
@@ -1,0 +1,1 @@
+nm-signal-0.svg

--- a/status/symbolic/nm-signal-00-symbolic.svg
+++ b/status/symbolic/nm-signal-00-symbolic.svg
@@ -1,0 +1,1 @@
+nm-signal-00.svg

--- a/status/symbolic/nm-signal-100-symbolic.svg
+++ b/status/symbolic/nm-signal-100-symbolic.svg
@@ -1,0 +1,1 @@
+nm-signal-100.svg

--- a/status/symbolic/nm-signal-25-symbolic.svg
+++ b/status/symbolic/nm-signal-25-symbolic.svg
@@ -1,0 +1,1 @@
+nm-signal-25.svg

--- a/status/symbolic/nm-signal-50-symbolic.svg
+++ b/status/symbolic/nm-signal-50-symbolic.svg
@@ -1,0 +1,1 @@
+nm-signal-50.svg

--- a/status/symbolic/nm-signal-75-symbolic.svg
+++ b/status/symbolic/nm-signal-75-symbolic.svg
@@ -1,0 +1,1 @@
+nm-signal-75.svg


### PR DESCRIPTION
<!-- Please describe your changes below. -->
### Description

in this case, it will change the xfce4-panel Status Notifier Plugin icon
<!--

    If you are submitting a new icon, include a PNG preview
    of the icon below.

    If you are submitting an icon *revision*, include a PNG
    preview of the old icon, and the new iconn side-by-side.
    You may use a table such as the following:

    | Icon name     | Old Icon     | New Icon     |
    | :------------ | ------------ | ------------ |
    | `coolapp.svg` | ![](old.png) | ![](new.png) |

-->
From:

![screenshot_2018-11-08_22-54-11](https://user-images.githubusercontent.com/20803810/48210471-f25d9e80-e3a9-11e8-8ddf-8ef84d7b2295.png)

![screenshot_2018-11-08_22-55-39](https://user-images.githubusercontent.com/20803810/48210491-fe496080-e3a9-11e8-89f4-5716f1489c6b.png)

To:

![screenshot_2018-11-08_22-57-32](https://user-images.githubusercontent.com/20803810/48210515-0bfee600-e3aa-11e8-820a-b97b62da176f.png)

![screenshot_2018-11-08_22-57-48](https://user-images.githubusercontent.com/20803810/48210536-1620e480-e3aa-11e8-96e0-7ef25e8e327e.png)