### PR TITLE
Add symlink for org.gnome.Contacts

### DIFF
--- a/apps/scalable/org.gnome.Contacts.svg
+++ b/apps/scalable/org.gnome.Contacts.svg
@@ -1,0 +1,1 @@
+gnome-contacts.svg


### PR DESCRIPTION
<!-- Please describe your changes below. -->
### Description

Fedora (more or less) recently updated the GNOME Contacts application to use `org.gnome.Contacts` as name for application launcher and icon.

This adds a symlink for that change.

<!--

    If you are submitting a new icon, include a PNG preview
    of the icon below.

    If you are submitting an icon *revision*, include a PNG
    preview of the old icon, and the new iconn side-by-side.
    You may use a table such as the following:

    | Icon name     | Old Icon     | New Icon     |
    | :------------ | ------------ | ------------ |
    | `coolapp.svg` | ![](old.png) | ![](new.png) |

-->

