### PR TITLE
Add support for intellij installed through jetbrains toolbox

### DIFF
--- a/apps/scalable/jetbrains-idea.svg
+++ b/apps/scalable/jetbrains-idea.svg
@@ -1,0 +1,1 @@
+intellij.svg


### PR DESCRIPTION
<!-- Please describe your changes below. -->
### Description

When Intellij IDEA is installed through JetBrains toolbox, the icon required is "jetbrains-idea" which does not have a symlink in the repo. I have added the required symlink by running `ln -s intellij.svg jetbrains-idea.svg`
