### PR TITLE
Fixed invalid symlinks

### DIFF
--- a/apps/scalable/gnome-logo-icon.svg
+++ b/apps/scalable/gnome-logo-icon.svg
@@ -1,1 +1,1 @@
-desktop-enviroment-gnome.svg
+desktop-environment-gnome.svg

--- a/apps/scalable/kde-logo.svg
+++ b/apps/scalable/kde-logo.svg
@@ -1,1 +1,1 @@
-desktop-enviroment-kde.svg
+desktop-environment-kde.svg

--- a/apps/scalable/kde-windows.svg
+++ b/apps/scalable/kde-windows.svg
@@ -1,1 +1,1 @@
-desktop-enviroment-kde.svg
+desktop-environment-kde.svg

--- a/apps/scalable/kde.svg
+++ b/apps/scalable/kde.svg
@@ -1,1 +1,1 @@
-desktop-enviroment-kde.svg
+desktop-environment-kde.svg

--- a/apps/scalable/mate.svg
+++ b/apps/scalable/mate.svg
@@ -1,1 +1,1 @@
-desktop-enviroment-mate.svg
+desktop-environment-mate.svg

--- a/apps/scalable/podcast-amarok.svg
+++ b/apps/scalable/podcast-amarok.svg
@@ -1,1 +1,1 @@
-podcast
+podcast.svg


### PR DESCRIPTION
<!-- Please describe your changes below. -->
### Description
Two typos made some symlinks invalid. One was a missing `.svg` extension, the others had a missing "n" in "environment"

<!--

    If you are submitting a new icon, include a PNG preview
    of the icon below.

    If you are submitting an icon *revision*, include a PNG
    preview of the old icon, and the new iconn side-by-side.
    You may use a table such as the following:

    | Icon name     | Old Icon     | New Icon     |
    | :------------ | ------------ | ------------ |
    | `coolapp.svg` | ![](old.png) | ![](new.png) |

-->

