### PR TITLE
Add symlinks for xfce4-clipman-plugin, thunar menu, and xfce4-color-settings

### DIFF
--- a/actions/22x22-dark/tap-extract-to.svg
+++ b/actions/22x22-dark/tap-extract-to.svg
@@ -1,0 +1,1 @@
+extract-archive.svg

--- a/actions/22x22-dark/tap-extract.svg
+++ b/actions/22x22-dark/tap-extract.svg
@@ -1,0 +1,1 @@
+extract-archive.svg

--- a/actions/22x22-light/tap-extract-to.svg
+++ b/actions/22x22-light/tap-extract-to.svg
@@ -1,0 +1,1 @@
+extract-archive.svg

--- a/actions/22x22-light/tap-extract.svg
+++ b/actions/22x22-light/tap-extract.svg
@@ -1,0 +1,1 @@
+extract-archive.svg

--- a/apps/scalable/xfce4-color-settings.svg
+++ b/apps/scalable/xfce4-color-settings.svg
@@ -1,0 +1,1 @@
+preferences-color.svg

--- a/status/scalable-dark/clipman-symbolic.svg
+++ b/status/scalable-dark/clipman-symbolic.svg
@@ -1,0 +1,1 @@
+clipit-trayicon.svg

--- a/status/scalable-light/clipman-symbolic.svg
+++ b/status/scalable-light/clipman-symbolic.svg
@@ -1,0 +1,1 @@
+clipit-trayicon.svg


### PR DESCRIPTION
<!-- Please describe your changes below. -->
### Description
In Thunar there are two elements in menu for archives called "Extract Here" and "Extract To..." that are missing la-captaine icons so I created a link to "extract-archive.svg" for both of them.
### Before 
![extract-before](https://user-images.githubusercontent.com/32198274/62944651-76333400-bddd-11e9-8920-bf98d9522bb9.png)

### After
![extract-after](https://user-images.githubusercontent.com/32198274/62944675-80edc900-bddd-11e9-8492-d533b2a7ac6e.png)



Clipman plugin is also missing an icon so I created a link to "clipit-trayicon.svg"
### Before
![clipman-before](https://user-images.githubusercontent.com/32198274/62945457-0d4cbb80-bddf-11e9-8a74-0a52dcdd5426.png)

### After
![clipman-after](https://user-images.githubusercontent.com/32198274/62945465-1047ac00-bddf-11e9-83b7-518423eefb6e.png)



With 4.14 release Xfce gained new settings dialog to manage color profiles which is also missing an icon so I created a link to "preferences-color.svg" for it.
### Before
![color-profiles-before](https://user-images.githubusercontent.com/32198274/62944997-23a64780-bdde-11e9-9d9c-2eca08fb74d3.png)

### After
![color-profiles-after](https://user-images.githubusercontent.com/32198274/62945006-27d26500-bdde-11e9-80ca-96760968241a.png)


<!--

    If you are submitting a new icon, include a PNG preview
    of the icon below.

    If you are submitting an icon *revision*, include a PNG
    preview of the old icon, and the new iconn side-by-side.
    You may use a table such as the following:

    | Icon name     | Old Icon     | New Icon     |
    | :------------ | ------------ | ------------ |
    | `coolapp.svg` | ![](old.png) | ![](new.png) |

-->

