### PR TITLE
Fix gitkraken.svg rendering in Qt

### DIFF
--- a/apps/scalable/gitkraken.svg
+++ b/apps/scalable/gitkraken.svg
@@ -8,7 +8,7 @@
     <stop offset="0" stop-color="#ececec" />
     <stop offset="1" stop-color="#fff" />
   </linearGradient>
-  <linearGradient id="d" gradientUnits="userSpaceOnUse" x1="24.476965" x2="24.000015" xlink:href="#c" y1="46.041661" y2="2.000004">
+  <linearGradient id="d" gradientUnits="userSpaceOnUse" x1="24.476965" x2="24.000015" y1="46.041661" y2="2.000004">
     <stop offset="0" stop-color="#128379" />
     <stop offset="1" stop-color="#15a497" />
   </linearGradient>


### PR DESCRIPTION
<!-- Please describe your changes below. -->
### Description

Fixes #467. I removed a reference which made the gradient inherit white colors.

| Icon name     | Old Icon     | New Icon    |
| ----------------- | ------------- | --------------- |
| `gitkraken.svg` | ![old](https://i.imgur.com/Q2vskZG.png) | ![fixed](https://i.imgur.com/z20qIKi.png) |
