### PR TITLE
symlink xournal --> com.github.xournalpp.xournalpp

### DIFF
--- a/apps/scalable/com.github.xournalpp.xournalpp.svg
+++ b/apps/scalable/com.github.xournalpp.xournalpp.svg
@@ -1,0 +1,1 @@
+xournal.svg


### PR DESCRIPTION

### Description
[Xournal++](https://github.com/xournalpp/xournalpp/) is a fork of Xournal, and it was missing from la-capitaine-icon-theme. 

I have symlinked `xournal.svg` --> `com.github.xournalpp.xournalpp.svg`.

I also confirmed that Xournal++ is now using the icon of Xournal after creating this symlink.
